### PR TITLE
[#13] add new api tests for complete order and cancel order actions 

### DIFF
--- a/tests/api/cart.api.test.js
+++ b/tests/api/cart.api.test.js
@@ -1,41 +1,120 @@
 const { test, expect } = require('@playwright/test')
 
 const { getAuthToken, getProductBody, getProductId, getCartBody, getCartId } = require('../../lib/helpers')
-  
+
 test.describe.parallel('Carts API', () => {
   let authorization
-  
+
   test.beforeAll(async ({ request }) => {
     authorization = await getAuthToken(request)
   })
-  
+
   test('retrieves the list of carts', async ({ request }) => {
     const response = await request.get('/carrinhos')
-    
+
+    await expect(response).toBeOK()
+  })
+
+  test('retrieves an existing cart by its id', async ({ request }) => {
+    const idProduct = await getProductId(request, authorization, getProductBody())
+    const _id = await getCartId(request, authorization, getCartBody(idProduct))
+
+    const response = await request.get(`/carrinhos/${_id}`)
+
     await expect(response).toBeOK()
   })
 
   test('creates a cart successfully', async ({ request }) => {
-    const id = await getProductId(request, authorization, getProductBody())
+    const authorization = await getAuthToken(request)
+    const idProduct = await getProductId(request, authorization, getProductBody())
 
     const response = await request.post('/carrinhos', {
-      data: getCartBody(id),
+      data: getCartBody(idProduct),
       headers: { 'Authorization': authorization }
     })
 
     await expect(response).toBeOK()
 
     const responseBody = JSON.parse(await response.text())
-    
+
     await expect(responseBody.message).toBe('Cadastro realizado com sucesso')
   })
 
-  test('retrieves an existing cart by its id', async ({ request }) => {
+  test('delete an order successfully', async ({ request }) => {
     const idProduct = await getProductId(request, authorization, getProductBody())
-    const _id = await getCartId(request, authorization, getCartBody(idProduct))
-    
-    const response = await request.get(`/carrinhos/${_id}`)
-    
+    await getCartId(request, authorization, getCartBody(idProduct))
+
+    const response = await request.delete('/carrinhos/concluir-compra', {
+      headers: { 'Authorization': authorization }
+    })
+
     await expect(response).toBeOK()
+
+    const responseBody = JSON.parse(await response.text())
+
+    await expect(responseBody.message).toBe('Registro excluído com sucesso')
+  })
+
+  test('delete an order without a cart', async ({ request }) => {
+    const response = await request.delete('/carrinhos/concluir-compra', {
+      headers: { 'Authorization': authorization }
+    })
+
+    await expect(response).toBeOK()
+
+    const responseBody = JSON.parse(await response.text())
+
+    await expect(responseBody.message).toBe('Não foi encontrado carrinho para esse usuário')
+  })
+
+  test('delete an order without a token', async ({ request }) => {
+    const response = await request.delete('/carrinhos/concluir-compra', {
+      headers: { 'Authorization': '' }
+    })
+
+    await expect(response).not.toBeOK()
+
+    const responseBody = JSON.parse(await response.text())
+
+    await expect(responseBody.message).toBe('Token de acesso ausente, inválido, expirado ou usuário do token não existe mais')
+  })
+
+  test('cancel an order successfully', async ({ request }) => {
+    const idProduct = await getProductId(request, authorization, getProductBody())
+    await getCartId(request, authorization, getCartBody(idProduct))
+
+    const response = await request.delete('/carrinhos/cancelar-compra', {
+      headers: { 'Authorization': authorization }
+    })
+
+    await expect(response).toBeOK()
+
+    const responseBody = JSON.parse(await response.text())
+
+    await expect(responseBody.message).toBe('Registro excluído com sucesso. Estoque dos produtos reabastecido')
+  })
+
+  test('cancel an order without a cart', async ({ request }) => {
+    const response = await request.delete('/carrinhos/cancelar-compra', {
+      headers: { 'Authorization': authorization }
+    })
+
+    await expect(response).toBeOK()
+
+    const responseBody = JSON.parse(await response.text())
+
+    await expect(responseBody.message).toBe('Não foi encontrado carrinho para esse usuário')
+  })
+
+  test('cancel an order without a token', async ({ request }) => {
+    const response = await request.delete('/carrinhos/cancelar-compra', {
+      headers: { 'Authorization': '' }
+    })
+
+    await expect(response).not.toBeOK()
+
+    const responseBody = JSON.parse(await response.text())
+
+    await expect(responseBody.message).toBe('Token de acesso ausente, inválido, expirado ou usuário do token não existe mais')
   })
 })


### PR DESCRIPTION
### Description 

I'm creating new test scenarios to **cancel and delete an order** in the cart.

The task can be [seen here](https://github.com/stefanteixeira/demo-playwright-test/projects/1#card-83560698).

### How to test

- `yarn install && yarn test:api`

### Checklist

- [x] Branch name follows the pattern: `concise-feature-description`
- [x] PR has a descriptive name
- [x] PR branch is up-to-date with `main` (if not, rebase it)
- [x] Double-check the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
