### PR TITLE
Add http status codes lib on the api tests

### DIFF
--- a/tests/api/login.api.test.js
+++ b/tests/api/login.api.test.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test')
-
+const { StatusCodes } = require('http-status-codes')
+const { LOGIN_SUCESS, LOGIN_FAIL } = require('serverest/src/utils/constants')
 const { getUserBody } = require('../../lib/helpers')
 
 test.describe.parallel('Login API', () => {
@@ -18,8 +19,10 @@ test.describe.parallel('Login API', () => {
     }
 
     const response = await request.post('/login', { data: loginBody })
+    const login = await response.json()
 
-    await expect(response).toBeOK()
+    expect(response.status()).toEqual(StatusCodes.OK)
+    expect(login.message).toEqual(LOGIN_SUCESS)
   })
 
   test('fails to login if user email is invalid', async ({ request }) => {
@@ -29,8 +32,10 @@ test.describe.parallel('Login API', () => {
     }
 
     const response = await request.post('/login', { data: loginBody })
+    const login = await response.json()
 
-    await expect(response).not.toBeOK()
+    expect(response.status()).toEqual(StatusCodes.UNAUTHORIZED)
+    expect(login.message).toEqual(LOGIN_FAIL)
   })
 
   test('fails to login if user password is invalid', async ({ request }) => {
@@ -40,7 +45,9 @@ test.describe.parallel('Login API', () => {
     }
 
     const response = await request.post('/login', { data: loginBody })
+    const login = await response.json()
 
-    await expect(response).not.toBeOK()
+    expect(response.status()).toEqual(StatusCodes.UNAUTHORIZED)
+    expect(login.message).toEqual(LOGIN_FAIL)
   })
 })

--- a/tests/api/product.api.test.js
+++ b/tests/api/product.api.test.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test')
-
+const { StatusCodes } = require('http-status-codes')
+const { POST_SUCESS, DELETE_SUCESS, PUT_SUCESS, TOKEN_INVALID, NOME_JA_USADO } = require('serverest/src/utils/constants')
 const { getAuthToken, getProductBody, getProductId } = require('../../lib/helpers')
 
 test.describe.parallel('Product API', () => {
@@ -12,7 +13,7 @@ test.describe.parallel('Product API', () => {
   test('retrieves the list of products', async ({ request }) => {
     const response = await request.get('/produtos')
 
-    await expect(response).toBeOK()
+    expect(response.status()).toEqual(StatusCodes.OK)
   })
 
   test('creates a product successfully', async ({ request }) => {
@@ -20,62 +21,73 @@ test.describe.parallel('Product API', () => {
       data: getProductBody(),
       headers: { 'Authorization': authorization }
     })
+    const product = await response.json()
 
-    await expect(response).toBeOK()
+    expect(response.status()).toEqual(StatusCodes.CREATED)
+    expect(product.message).toEqual(POST_SUCESS)
   })
 
   test('retrieves an existing product by its id', async ({ request }) => {
-    const id = await getProductId(request, authorization, getProductBody())
-    const response = await request.get(`/produtos/${id}`)
+    const _id = await getProductId(request, authorization, getProductBody())
+    const response = await request.get(`/produtos/${_id}`)
 
-    await expect(response).toBeOK()
+    expect(response.status()).toEqual(StatusCodes.OK)
   })
 
   test('deletes a product successfully', async ({ request }) => {
-    const id = await getProductId(request, authorization, getProductBody())
-    const response = await request.delete(`/produtos/${id}`, {
+    const _id = await getProductId(request, authorization, getProductBody())
+    const response = await request.delete(`/produtos/${_id}`, {
       headers: { 'Authorization': authorization }
     })
+    const product = await response.json()
 
-    await expect(response).toBeOK()
+    expect(response.status()).toEqual(StatusCodes.OK)
+    expect(product.message).toEqual(DELETE_SUCESS)
   })
 
   test('fails to delete a product when access token is not provided', async ({ request }) => {
-    const id = await getProductId(request, authorization, getProductBody())
-    const response = await request.delete(`/produtos/${id}`)
+    const _id = await getProductId(request, authorization, getProductBody())
 
-    await expect(response.status()).toEqual(401)
+    const response = await request.delete(`/produtos/${_id}`)
+    const product = await response.json()
+
+    expect(response.status()).toEqual(StatusCodes.UNAUTHORIZED)
+    expect(product.message).toEqual(TOKEN_INVALID)
   })
-  
-  test('edits a product successfully', async ({ request }) => { 
-    const id = await getProductId(request, authorization, getProductBody())
+
+  test('edits a product successfully', async ({ request }) => {
+    const _id = await getProductId(request, authorization, getProductBody())
     const editProduct = getProductBody()
 
-    const response = await request.put(`/produtos/${id}`, {
-      data: editProduct, 
+    const response = await request.put(`/produtos/${_id}`, {
+      data: editProduct,
       headers: { 'Authorization': authorization }
     })
-  
-    await expect(response).toBeOK()
+    const product = await response.json()
+
+    expect(response.status()).toEqual(StatusCodes.OK)
+    expect(product.message).toEqual(PUT_SUCESS)
   })
 
-  test('fails to edit a product if other product with the same name already exists', async ({ request }) => { 
+  test('fails to edit a product if other product with the same name already exists', async ({ request }) => {
     const product = getProductBody()
     await request.post('/produtos', {
       data: product,
       headers: { 'Authorization': authorization }
-    })    
+    })
 
     const { nome, ...rest } = getProductBody()
     const editProduct = {
-      nome: product.nome, 
+      nome: product.nome,
       ...rest
     }
     const response = await request.put('/produtos/nonExistingId', {
       data: editProduct,
       headers: { 'Authorization': authorization }
     })
-    
-    await expect(response.status()).toEqual(400)
+    const productJson = await response.json()
+
+    expect(response.status()).toEqual(StatusCodes.BAD_REQUEST)
+    expect(productJson.message).toEqual(NOME_JA_USADO)
   })
 })

--- a/tests/api/user.api.test.js
+++ b/tests/api/user.api.test.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test')
-
+const { StatusCodes } = require('http-status-codes')
+const { POST_SUCESS, EMAIL_JA_USADO, USUARIO_NAO_ENCONTRADO, DELETE_SUCESS, PUT_SUCESS } = require('serverest/src/utils/constants')
 const { getUserBody } = require('../../lib/helpers')
 
 const getUserId = async (request, body) => {
@@ -13,13 +14,15 @@ test.describe.parallel('User API', () => {
   test('retrieves the list of users', async ({ request }) => {
     const response = await request.get('/usuarios')
 
-    await expect(response).toBeOK()
+    expect(response.status()).toEqual(StatusCodes.OK)
   })
 
   test('creates a user successfully', async ({ request }) => {
     const response = await request.post('/usuarios', { data: getUserBody() })
+    const responseBody = await response.json()
 
-    await expect(response).toBeOK()
+    expect(response.status()).toEqual(StatusCodes.CREATED)
+    expect(responseBody.message).toEqual(POST_SUCESS)
   })
 
   test('fails to create a user if it already exists', async ({ request }) => {
@@ -27,46 +30,58 @@ test.describe.parallel('User API', () => {
     await request.post('/usuarios', { data: body })
 
     const response = await request.post('/usuarios', { data: body })
+    const responseBody = await response.json()
 
-    await expect(response).not.toBeOK()
+    expect(response.status()).toEqual(StatusCodes.BAD_REQUEST)
+    expect(responseBody.message).toEqual(EMAIL_JA_USADO)
   })
 
   test('retrieves an existing user by its id', async ({ request }) => {
-    const id = await getUserId(request, getUserBody())
+    const _id = await getUserId(request, getUserBody())
 
-    const response = await request.get(`/usuarios/${id}`)
+    const response = await request.get(`/usuarios/${_id}`)
+    const responseBody = await response.json()
 
-    await expect(response).toBeOK()
+    expect(response.status()).toEqual(StatusCodes.OK)
+    expect(responseBody._id).toEqual(_id)
   })
 
   test('fails to retrieve a user if it does not exist', async ({ request }) => {
     const response = await request.get('/usuarios/nonExistingId')
+    const responseBody = await response.json()
 
-    await expect(response).not.toBeOK()
+    expect(response.status()).toEqual(StatusCodes.BAD_REQUEST)
+    expect(responseBody.message).toEqual(USUARIO_NAO_ENCONTRADO)
   })
 
   test('deletes a user successfully', async ({ request }) => {
-    const id = await getUserId(request, getUserBody())
+    const _id = await getUserId(request, getUserBody())
 
-    const response = await request.delete(`/usuarios/${id}`)
+    const response = await request.delete(`/usuarios/${_id}`)
+    const responseBody = await response.json()
 
-    await expect(response).toBeOK()
+    expect(response.status()).toEqual(StatusCodes.OK)
+    expect(responseBody.message).toEqual(DELETE_SUCESS)
   })
 
   test('edits a user successfully', async ({ request }) => {
-    const id = await getUserId(request, getUserBody())
+    const _id = await getUserId(request, getUserBody())
     const editBody = getUserBody()
 
-    const response = await request.put(`/usuarios/${id}`, { data: editBody })
+    const response = await request.put(`/usuarios/${_id}`, { data: editBody })
+    const responseBody = await response.json()
 
-    await expect(response.status()).toEqual(200)
+    expect(response.status()).toEqual(StatusCodes.OK)
+    expect(responseBody.message).toEqual(PUT_SUCESS)
   })
 
   test('creates a user by editing a non-existing one', async ({ request }) => {
     const editBody = getUserBody()
 
     const response = await request.put('/usuarios/nonExistingId', { data: editBody })
+    const responseBody = await response.json()
 
-    await expect(response.status()).toEqual(201)
+    expect(response.status()).toEqual(StatusCodes.CREATED)
+    expect(responseBody.message).toEqual(POST_SUCESS)
   })
 })


### PR DESCRIPTION
### Description 

Using new lib to validate `status code` and using Serverest package with its constants.
The task can be [seen here](https://github.com/stefanteixeira/demo-playwright-test/projects/1#card-84759365).

### How to test

- `yarn install && yarn test:api`

### Checklist

- [x] Branch name follows the pattern: `concise-feature-description`
- [x] PR has a descriptive name
- [x] PR branch is up-to-date with `main` (if not, rebase it)
- [x] Double-check the quality of [commit messages](http://chris.beams.io/posts/git-commit/)