### PR TITLE
Refactoring api tests to use response.json()

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,7 +23,7 @@ const getProductId = async (request, authorization, body) => {
     data: body,
     headers: { 'Authorization': authorization }
   })
-  const responseBody = JSON.parse(await response.text())
+  const responseBody = await response.json()
   return responseBody._id
 }
 
@@ -43,7 +43,7 @@ const getCartId = async (request, authorization, body) => {
     data: body,
     headers: { 'Authorization': authorization }
   })
-  const responseBody = JSON.parse(await response.text())
+  const responseBody = await response.json()
   return responseBody._id
 }
 
@@ -71,7 +71,7 @@ const getAuthToken = async request => {
 
   await request.post('/usuarios', { data: body })
   const response = await request.post('/login', { data: loginBody })
-  const responseBody = JSON.parse(await response.text())
+  const responseBody = await response.json()
 
   return responseBody.authorization
 }

--- a/tests/api/user.api.test.js
+++ b/tests/api/user.api.test.js
@@ -5,7 +5,7 @@ const { getUserBody } = require('../../lib/helpers')
 
 const getUserId = async (request, body) => {
   const response = await request.post('/usuarios', { data: body })
-  const responseBody = JSON.parse(await response.text())
+  const responseBody = await response.json()
 
   return responseBody._id
 }


### PR DESCRIPTION
### Description 

In order to increase readability, all the occurrences of `response.text()` used in the api tests so far have been replaced by `response.json()`.

### How to test

- `yarn install`
- `yarn api:start`
- `yarn test:api`

### Checklist

- [x] Branch name follows the pattern: `concise-feature-description`
- [x] PR has a descriptive name
- [x] PR branch is up-to-date with `main` (if not, rebase it)
- [x] Double-check the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
