### PR TITLE
Add example of schema validation test with Joi

### DIFF
--- a/lib/expect-schema.js
+++ b/lib/expect-schema.js
@@ -1,0 +1,19 @@
+const toMatchSchema = (received, schema) => {
+  const { error } = schema.validate(received, { presence: 'required' })
+  const pass = !error
+
+  if (pass) {
+    return {
+      pass: true
+    }
+  }
+
+  return {
+    message: () => `${error}`,
+    pass: false
+  }
+}
+
+module.exports = {
+  toMatchSchema
+}

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,0 +1,13 @@
+const Joi = require('joi')
+
+const PRODUCT_SCHEMA = Joi.object({
+  nome: Joi.string(),
+  preco: Joi.number(),
+  descricao: Joi.string(),
+  quantidade: Joi.number(),
+  _id: Joi.string()
+})
+
+module.exports = {
+  PRODUCT_SCHEMA
+}

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "axe-playwright": "^1.1.11",
     "eslint": "^8.15.0",
     "eslint-plugin-playwright": "^0.9.0",
-    "expect-playwright": "^0.8.0",
     "happo-e2e": "^1.2.0",
     "happo-playwright": "^1.1.0",
     "happo.io": "^7.2.1",
     "http-status-codes": "^2.2.0",
+    "joi": "^17.6.0",
     "playwright": "^1.22.1",
     "serverest": "2.26.2",
     "wait-on": "^6.0.1"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,7 @@
-const { matchers } = require('expect-playwright')
 const { expect } = require('@playwright/test')
+const toMatchSchema = require('./lib/expect-schema')
 
-expect.extend(matchers)
+expect.extend(toMatchSchema)
 
 process.env.PLAYWRIGHT_EXPERIMENTAL_FEATURES = '1'
 

--- a/tests/api/product.api.test.js
+++ b/tests/api/product.api.test.js
@@ -9,6 +9,7 @@ const {
   PRODUCT_NOT_FOUND
 } = require('serverest/src/utils/constants')
 const { getAuthToken, getProductBody, getProductId, getUserBody } = require('../../lib/helpers')
+const { PRODUCT_SCHEMA } = require('../../lib/schemas')
 
 test.describe.parallel('Product API', () => {
   let authorization
@@ -54,6 +55,14 @@ test.describe.parallel('Product API', () => {
     const response = await request.get(`/produtos/${_id}`)
 
     expect(response.status()).toEqual(StatusCodes.OK)
+  })
+
+  test('validates product schema', async ({ request }) => {
+    const _id = await getProductId(request, authorization, getProductBody())
+    const response = await request.get(`/produtos/${_id}`)
+    const product = await response.json()
+
+    expect(product).toMatchSchema(PRODUCT_SCHEMA)
   })
 
   test('fails to retrieve a product when it does not exist', async ({ request }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,11 +1210,6 @@ event-loop-stats@1.2.0:
   dependencies:
     nan "^2.14.0"
 
-expect-playwright@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/expect-playwright/-/expect-playwright-0.8.0.tgz#6d4ebe0bdbdd3c1693d880d97153b96a129ae4e8"
-  integrity sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==
-
 express-async-errors@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"


### PR DESCRIPTION
### Description 

Adding a simple schema validation test with [Joi](https://joi.dev/api/?v=17.6.0), to demonstrate how it can be done. Also, removing `expect-playwright` lib, which was unnecessary (closes #42)
 
### How to test

- `yarn install`
- `yarn api:start`
- `yarn test:api`

### Checklist

- [x] Branch name follows the pattern: `concise-feature-description`
- [x] PR has a descriptive name
- [x] PR branch is up-to-date with `main` (if not, rebase it)
- [x] Double-check the quality of [commit messages](http://chris.beams.io/posts/git-commit/)
